### PR TITLE
Fix misspelled variable name s/learing_arg/learning_arg/

### DIFF
--- a/install/etc/services.available/10-spamassassin/run
+++ b/install/etc/services.available/10-spamassassin/run
@@ -27,4 +27,4 @@ exec spamd \
 			--syslog=${LOG_PATH}${LOG_FILE} \
 			--timeout-child=${TIMEOUT_CHILD} \
 			--timeout-tcp=${TIMEOUT_TCP} \
-			--nouser-config $debug_arg $learing_arg $round_robin_arg
+			--nouser-config $debug_arg $learning_arg $round_robin_arg


### PR DESCRIPTION
Hello

Tiny fix to a misspelling that is causing learning to not be enabled.

Thanks